### PR TITLE
Add mobile Flutter UI skeleton

### DIFF
--- a/core/orchestrator.py
+++ b/core/orchestrator.py
@@ -50,6 +50,13 @@ class Orchestrator:
             print("📡 Note10+ Bridge attivo – In ascolto microfono e comandi vocali.")
         except Exception as e:
             print(f"⚠️ Errore avvio Note10+ Jarvis: {e}")
+        # Avvia l'interfaccia mobile Flutter se disponibile
+        try:
+            from modules.mobile_flutter.flutter_bridge import start_mobile_ui
+            threading.Thread(target=start_mobile_ui, daemon=True).start()
+            print("📱 Mobile Jarvis UI attivo.")
+        except Exception as e:
+            print(f"⚠️ Errore avvio Mobile UI: {e}")
         print("✅ GENESIS attiva – Rete neurale in esecuzione.")
 
     def load_agents(self):
@@ -117,6 +124,12 @@ class Orchestrator:
                 start_jarvis_loop()
             except Exception as exc:
                 print(f"⚠️ Errore attivazione Note10 Jarvis: {exc}")
+        elif mission_name == "#ACTIVATE_MOBILE_UI":
+            try:
+                from modules.mobile_flutter.flutter_bridge import start_mobile_ui
+                start_mobile_ui()
+            except Exception as exc:
+                print(f"⚠️ Errore attivazione Mobile UI: {exc}")
         else:
             print(f"⚠️ Missione sconosciuta: {mission_name}")
 

--- a/mobile_jarvis_ui/README.md
+++ b/mobile_jarvis_ui/README.md
@@ -1,0 +1,5 @@
+# Mobile Jarvis UI
+
+Flutter-based HUD interface for Mercurius∞. This app provides a continuous voice assistant with a Jarvis style holographic UI. It communicates with the Mercurius backend via HTTP and plays responses using TTS.
+
+This is a minimal skeleton; build the project using Flutter SDK.

--- a/mobile_jarvis_ui/assets/placeholder.txt
+++ b/mobile_jarvis_ui/assets/placeholder.txt
@@ -1,0 +1,1 @@
+placeholder

--- a/mobile_jarvis_ui/lib/main.dart
+++ b/mobile_jarvis_ui/lib/main.dart
@@ -1,0 +1,106 @@
+import 'dart:async';
+import 'package:flutter/material.dart';
+import 'package:speech_to_text/speech_to_text.dart' as stt;
+import 'package:flutter_tts/flutter_tts.dart';
+import 'package:http/http.dart' as http;
+import 'dart:convert';
+
+void main() => runApp(const JarvisApp());
+
+class JarvisApp extends StatelessWidget {
+  const JarvisApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      debugShowCheckedModeBanner: false,
+      title: 'Aion HUD',
+      theme: ThemeData.dark(),
+      home: const JarvisHomePage(),
+    );
+  }
+}
+
+class JarvisHomePage extends StatefulWidget {
+  const JarvisHomePage({super.key});
+
+  @override
+  State<JarvisHomePage> createState() => _JarvisHomePageState();
+}
+
+class _JarvisHomePageState extends State<JarvisHomePage> {
+  final stt.SpeechToText _speech = stt.SpeechToText();
+  final FlutterTts _tts = FlutterTts();
+  bool _isListening = false;
+  String _lastWords = '';
+  String _response = '';
+
+  Future<void> _listen() async {
+    if (!_isListening) {
+      bool available = await _speech.initialize();
+      if (available) {
+        setState(() => _isListening = true);
+        _speech.listen(onResult: (val) {
+          setState(() => _lastWords = val.recognizedWords);
+          if (val.hasConfidenceRating && val.confidence > 0) {
+            _askBackend(_lastWords);
+          }
+        });
+      }
+    } else {
+      setState(() => _isListening = false);
+      _speech.stop();
+    }
+  }
+
+  Future<void> _askBackend(String prompt) async {
+    try {
+      final resp = await http.post(
+        Uri.parse('http://localhost:8000/ask'),
+        headers: {'Content-Type': 'application/json'},
+        body: jsonEncode({'prompt': prompt}),
+      ).timeout(const Duration(seconds: 5));
+      if (resp.statusCode == 200) {
+        final data = jsonDecode(resp.body);
+        _response = data['response'] ?? '';
+        _speak(_response);
+        setState(() {});
+      }
+    } catch (_) {
+      _speak('Attenda un istante, sto raccogliendo i dati Signore...');
+    }
+  }
+
+  Future<void> _speak(String text) async {
+    await _tts.setLanguage('it-IT');
+    await _tts.speak(text);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.black,
+      body: Center(
+        child: GestureDetector(
+          onTap: _listen,
+          child: AnimatedContainer(
+            duration: const Duration(milliseconds: 300),
+            width: _isListening ? 200 : 150,
+            height: _isListening ? 200 : 150,
+            decoration: BoxDecoration(
+              color: Colors.tealAccent.withOpacity(0.2),
+              shape: BoxShape.circle,
+              border: Border.all(color: Colors.tealAccent),
+            ),
+            child: Center(
+              child: Text(
+                _isListening ? 'Ascolto...' : 'Aion',
+                style: const TextStyle(color: Colors.tealAccent, fontSize: 24),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/mobile_jarvis_ui/pubspec.yaml
+++ b/mobile_jarvis_ui/pubspec.yaml
@@ -1,0 +1,25 @@
+name: mobile_jarvis_ui
+description: Jarvis-like HUD for Mercurius∞
+version: 0.1.0
+environment:
+  sdk: '>=3.3.0 <4.0.0'
+dependencies:
+  flutter:
+    sdk: flutter
+  rive: ^0.11.17
+  flutter_tts: ^3.7.0
+  flutter_sound: ^9.2.13
+  speech_to_text: ^5.8.0
+  permission_handler: ^10.4.3
+  connectivity_plus: ^5.0.2
+  network_info_plus: ^4.0.1
+  wifi_scan: ^2.0.4
+  animated_background: ^2.0.0
+  http: ^0.13.5
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+flutter:
+  assets:
+    - assets/

--- a/modules/mobile_flutter/flutter_bridge.py
+++ b/modules/mobile_flutter/flutter_bridge.py
@@ -1,0 +1,21 @@
+"""Launcher for the Flutter-based mobile Jarvis UI."""
+from __future__ import annotations
+
+import subprocess
+import shutil
+from pathlib import Path
+
+PROJECT_DIR = Path(__file__).resolve().parent.parent.parent / "mobile_jarvis_ui"
+
+
+def start_mobile_ui() -> None:
+    """Attempt to launch the Flutter app."""
+    flutter = shutil.which("flutter")
+    if not flutter:
+        print("⚠️ Flutter SDK not found. Please run the app manually from mobile_jarvis_ui.")
+        return
+    try:
+        subprocess.Popen([flutter, "run", "-d", "android"], cwd=str(PROJECT_DIR))
+        print("📱 Mobile Jarvis UI launched")
+    except Exception as exc:
+        print(f"⚠️ Unable to launch Flutter app: {exc}")

--- a/tools/conflict_inspector.py
+++ b/tools/conflict_inspector.py
@@ -1,0 +1,24 @@
+"""Basic project conflict analyzer."""
+from __future__ import annotations
+
+import pkgutil
+from collections import defaultdict
+
+
+def scan_conflicts() -> None:
+    packages = defaultdict(list)
+    for module in pkgutil.iter_modules():
+        root = module.name.split('.')[0].lower()
+        packages[root].append(module.name)
+    conflicts = {k: v for k, v in packages.items() if len(v) > 1}
+    if not conflicts:
+        print("No obvious module name conflicts found.")
+        return
+    print("Potential conflicts detected:")
+    for base, mods in conflicts.items():
+        joined = ', '.join(mods)
+        print(f" - {base}: {joined}")
+
+
+if __name__ == "__main__":
+    scan_conflicts()


### PR DESCRIPTION
## Summary
- create Flutter project skeleton in `mobile_jarvis_ui`
- add launcher helper `modules/mobile_flutter/flutter_bridge.py`
- integrate mobile UI activation in `core/orchestrator.py`
- add simple conflict inspection tool

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for several optional dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68405b1eeedc832095f28089ee47ce2e