### PR TITLE
Implement Aion API and enhance mobile UI

### DIFF
--- a/deployment/aion_api.py
+++ b/deployment/aion_api.py
@@ -1,0 +1,29 @@
+from fastapi import FastAPI, WebSocket
+from llm.llm_router import LLMRouter
+import uvicorn
+
+app = FastAPI(title="Aion API")
+router = LLMRouter()
+
+@app.post("/ask")
+async def ask(payload: dict) -> dict:
+    text = payload.get("prompt", "")
+    if not text:
+        return {"response": ""}
+    reply = router.query(text)
+    return {"response": reply}
+
+@app.websocket("/ws")
+async def websocket_endpoint(websocket: WebSocket):
+    await websocket.accept()
+    try:
+        while True:
+            data = await websocket.receive_text()
+            reply = router.query(data)
+            await websocket.send_text(reply)
+    except Exception:
+        await websocket.close()
+
+
+def start_api(host: str = "0.0.0.0", port: int = 8000) -> None:
+    uvicorn.run(app, host=host, port=port)

--- a/logs/aion_activation_report.md
+++ b/logs/aion_activation_report.md
@@ -1,0 +1,6 @@
+# Aion Activation Report
+
+- Aion API server added (`deployment/aion_api.py`).
+- Boot script launches the API server automatically.
+- Flutter UI now detects hotwords and displays responses.
+- Use `flutter run -d android` to build the app.

--- a/mobile_jarvis_ui/README.md
+++ b/mobile_jarvis_ui/README.md
@@ -1,5 +1,12 @@
 # Mobile Jarvis UI
 
-Flutter-based HUD interface for Mercurius∞. This app provides a continuous voice assistant with a Jarvis style holographic UI. It communicates with the Mercurius backend via HTTP and plays responses using TTS.
+Flutter-based HUD interface for Mercurius∞. The app offers voice interaction using
+`speech_to_text` and `flutter_tts`, with simple hotword detection ("Hey Mercurius"
+or "Aion attivati"). Requests are sent to the local Aion API (`/ask`) which in
+turn forwards them to the orchestrator.
 
-This is a minimal skeleton; build the project using Flutter SDK.
+Build and run using the Flutter SDK on an Android device:
+
+```bash
+flutter run -d android
+```

--- a/mobile_jarvis_ui/lib/main.dart
+++ b/mobile_jarvis_ui/lib/main.dart
@@ -34,6 +34,7 @@ class _JarvisHomePageState extends State<JarvisHomePage> {
   bool _isListening = false;
   String _lastWords = '';
   String _response = '';
+  final List<String> _hotwords = ['hey mercurius', 'aion attivati'];
 
   Future<void> _listen() async {
     if (!_isListening) {
@@ -42,7 +43,12 @@ class _JarvisHomePageState extends State<JarvisHomePage> {
         setState(() => _isListening = true);
         _speech.listen(onResult: (val) {
           setState(() => _lastWords = val.recognizedWords);
-          if (val.hasConfidenceRating && val.confidence > 0) {
+          final words = val.recognizedWords.toLowerCase();
+          if (_hotwords.any((hw) => words.contains(hw))) {
+            _speech.stop();
+            setState(() => _isListening = false);
+            _speak('Pronto, Signore.');
+          } else if (val.hasConfidenceRating && val.confidence > 0) {
             _askBackend(_lastWords);
           }
         });
@@ -81,24 +87,35 @@ class _JarvisHomePageState extends State<JarvisHomePage> {
     return Scaffold(
       backgroundColor: Colors.black,
       body: Center(
-        child: GestureDetector(
-          onTap: _listen,
-          child: AnimatedContainer(
-            duration: const Duration(milliseconds: 300),
-            width: _isListening ? 200 : 150,
-            height: _isListening ? 200 : 150,
-            decoration: BoxDecoration(
-              color: Colors.tealAccent.withOpacity(0.2),
-              shape: BoxShape.circle,
-              border: Border.all(color: Colors.tealAccent),
-            ),
-            child: Center(
-              child: Text(
-                _isListening ? 'Ascolto...' : 'Aion',
-                style: const TextStyle(color: Colors.tealAccent, fontSize: 24),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            GestureDetector(
+              onTap: _listen,
+              child: AnimatedContainer(
+                duration: const Duration(milliseconds: 300),
+                width: _isListening ? 200 : 150,
+                height: _isListening ? 200 : 150,
+                decoration: BoxDecoration(
+                  color: Colors.tealAccent.withOpacity(0.2),
+                  shape: BoxShape.circle,
+                  border: Border.all(color: Colors.tealAccent),
+                ),
+                child: Center(
+                  child: Text(
+                    _isListening ? 'Ascolto...' : 'Aion',
+                    style: const TextStyle(color: Colors.tealAccent, fontSize: 24),
+                  ),
+                ),
               ),
             ),
-          ),
+            const SizedBox(height: 20),
+            Text(
+              _response,
+              textAlign: TextAlign.center,
+              style: const TextStyle(color: Colors.tealAccent),
+            ),
+          ],
         ),
       ),
     );

--- a/scripts/aion_boot.py
+++ b/scripts/aion_boot.py
@@ -24,6 +24,14 @@ def main():
     orchestrator.execute_mission("#SELF_MISSION")
 
     try:
+        from deployment.aion_api import start_api
+        import threading
+        threading.Thread(target=start_api, daemon=True).start()
+        print("🌐 Aion API server avviato sulla porta 8000")
+    except Exception as exc:
+        print(f"⚠️ Avvio Aion API fallito: {exc}")
+
+    try:
         from modules.voice_bridge.voice_loop import start_listening
         print("🎙️ Voice recognition attiva...")
         start_listening()


### PR DESCRIPTION
## Summary
- add a FastAPI server (`aion_api.py`) providing `/ask` and websocket endpoints
- launch the API server from `aion_boot.py`
- improve Flutter Jarvis UI with basic hotword detection and response display
- document new Flutter behaviour
- record activation notes in `aion_activation_report.md`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pyttsx3', 'openai', 'fitz', 'yaml', 'psutil')*

------
https://chatgpt.com/codex/tasks/task_e_684086d8000083208a1000b9f3a36e7e