### PR TITLE
Fix speech fallback and add goal utilities

### DIFF
--- a/modules/goal_manager.py
+++ b/modules/goal_manager.py
@@ -46,6 +46,23 @@ class GoalManager:
         """Restituisce la lista di goal attivi (status active e non done)."""
         return [g for g in self._goals if g.status == "active" and not g.done]
 
+    def pending_goals(self) -> List[Goal]:
+        """Ritorna i goal ancora in attesa di essere attivati."""
+        return [g for g in self._goals if g.status == "pending" and not g.done]
+
+    def all_goals(self) -> List[Dict[str, Any]]:
+        """Rappresentazione serializzabile di tutti i goal."""
+        return [
+            {
+                "name": g.name,
+                "priority": g.priority,
+                "context": g.context,
+                "status": g.status,
+                "done": g.done,
+            }
+            for g in self._goals
+        ]
+
 # Esempio di utilizzo
 if __name__ == "__main__":
     gm = GoalManager()

--- a/modules/speech.py
+++ b/modules/speech.py
@@ -4,7 +4,10 @@ Responsabilità: Gestione input vocale (ASR) e output vocale (TTS)
 Autore: Mercurius∞ Engineer Mode
 """
 
-import pyttsx3
+try:
+    import pyttsx3
+except Exception:  # pragma: no cover - optional engine
+    pyttsx3 = None
 import speech_recognition as sr
 
 
@@ -13,10 +16,17 @@ class TextToSpeech:
     Sintesi vocale basata su pyttsx3.
     """
     def __init__(self, voice_id=None):
-        self.engine = pyttsx3.init()
-        self.set_voice(voice_id)
+        self.engine = None
+        if pyttsx3 is not None:
+            try:
+                self.engine = pyttsx3.init()
+                self.set_voice(voice_id)
+            except Exception:
+                self.engine = None
 
     def set_voice(self, voice_id):
+        if not self.engine:
+            return
         if voice_id is not None:
             self.engine.setProperty('voice', voice_id)
         else:
@@ -25,8 +35,11 @@ class TextToSpeech:
                 self.engine.setProperty('voice', voices[0].id)
 
     def speak(self, text: str):
-        self.engine.say(text)
-        self.engine.runAndWait()
+        if self.engine:
+            self.engine.say(text)
+            self.engine.runAndWait()
+        else:
+            print(f"[TTS] {text}")
 
 
 class SpeechToText:

--- a/orchestrator/autonomy_controller.py
+++ b/orchestrator/autonomy_controller.py
@@ -43,6 +43,10 @@ class AutonomyController:
                 if success
                 else "Apprendimento registrato: rinforzo negativo."
             ),
+            # riflessione di base sull'esito dell'azione
+            "reflection": (
+                "successo" if success else "fallimento"
+            ),
         }
         self.experience_log.append(experience)
         print(


### PR DESCRIPTION
## Summary
- add reflection return in `AutonomyController.process_experience`
- implement `pending_goals` and `all_goals` in `GoalManager`
- make `TextToSpeech` robust if pyttsx3/espeak not available

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841b1b4cc4c8320bd97b3615d1a2c1c