### PR TITLE
Add self-evolving Mission Controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,14 @@ python scripts/aion_boot.py
 ```
 
 Il comando abilita la rete di agenti (OpenAI, Ollama, AZR), la voce (Whisper + gTTS) e la visione YOLO tramite webcam IP.
+
+## 🛰 Mission Controller Evolutivo
+Il file `orchestrator/mission_controller.py` introduce un controller che gestisce un ciclo di self-questioning tra gli agenti (Reasoner, AZR e Codex). Ogni workspace contiene un prompt dedicato e il controller salva log e patch generate in automatico.
+
+Per una prova rapida è disponibile la GUI Streamlit:
+
+```bash
+streamlit run modules/dashboard/mission_gui.py
+```
+
+Da qui è possibile creare nuovi workspace, avviare il ciclo evolutivo e visualizzare i log della sandbox.

--- a/modules/dashboard/mission_gui.py
+++ b/modules/dashboard/mission_gui.py
@@ -1,0 +1,34 @@
+"""mission_gui.py
+GUI minimale per interagire con il Mission Controller.
+"""
+
+import streamlit as st
+from orchestrator.mission_controller import MissionController
+
+st.set_page_config(page_title="Mission Control")
+
+if "controller" not in st.session_state:
+    st.session_state.controller = MissionController()
+
+mc = st.session_state.controller
+
+st.title("🚀 Mercurius∞ Mission Control")
+
+with st.form("new_workspace"):
+    name = st.text_input("Nome workspace", "workspace1")
+    prompt = st.text_area("Prompt o progetto")
+    submitted = st.form_submit_button("Crea workspace")
+    if submitted:
+        mc.create_workspace(name, prompt)
+        st.success(f"Workspace '{name}' creato")
+
+selected = st.selectbox("Scegli workspace", list(mc.workspaces.keys())) if mc.workspaces else None
+if selected:
+    if st.button("Esegui ciclo evolutivo"):
+        mc.run_cycle(selected)
+        st.success("Ciclo completato")
+    if st.checkbox("Mostra log" ):
+        log_path = mc.workspaces[selected]["path"] / "sandbox.log"
+        if log_path.exists():
+            st.text(log_path.read_text())
+

--- a/orchestrator/mission_controller.py
+++ b/orchestrator/mission_controller.py
@@ -1,0 +1,79 @@
+"""mission_controller.py
+Mission Controller per ciclo evolutivo multi-agente.
+"""
+
+from __future__ import annotations
+
+import os
+import json
+from pathlib import Path
+from typing import Dict, Any
+
+from orchestrator.genesis_orchestrator import GenesisOrchestrator
+from orchestrator.autonomy_controller import AutonomyController
+from modules.llm.azr_reasoner import AZRAgent
+from modules.gpt_engineer_wrapper import GPTEngineerWrapper
+from modules.sandbox_executor.secure_executor import SecureExecutor
+
+
+class MissionController:
+    """Gestisce il ciclo di self-questioning e auto-evoluzione."""
+
+    def __init__(self, base_dir: str = "workspaces") -> None:
+        self.base_dir = Path(base_dir)
+        self.base_dir.mkdir(exist_ok=True)
+        self.genesis = GenesisOrchestrator()
+        self.autonomy = AutonomyController()
+        self.azr = AZRAgent()
+        self.codex = GPTEngineerWrapper(project_path=str(self.base_dir))
+        self.executor = SecureExecutor(timeout=5)
+        self.workspaces: Dict[str, Dict[str, Any]] = {}
+        self.log_file = Path("logs/mission_log.jsonl")
+        self.log_file.parent.mkdir(exist_ok=True)
+
+    # ------------------------------------------------------------------ #
+    def create_workspace(self, name: str, prompt: str) -> Path:
+        """Crea una cartella dedicata e salva il prompt."""
+        path = self.base_dir / name
+        path.mkdir(exist_ok=True)
+        (path / "prompt.txt").write_text(prompt, encoding="utf-8")
+        self.workspaces[name] = {"prompt": prompt, "path": path}
+        self._log("workspace_created", {"name": name})
+        return path
+
+    # ------------------------------------------------------------------ #
+    def _log(self, event: str, details: Dict[str, Any]) -> None:
+        entry = {"event": event, "details": details}
+        with self.log_file.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(entry) + "\n")
+
+    # ------------------------------------------------------------------ #
+    def run_cycle(self, name: str) -> None:
+        """Esegue un ciclo evolutivo sul workspace indicato."""
+        ws = self.workspaces.get(name)
+        if not ws:
+            return
+        prompt = ws["prompt"]
+        # 1. Reasoner: suggerimenti
+        question = f"Come migliorare questo progetto? {prompt}"
+        reason_resp = self.genesis.route_task(question)
+        self.autonomy.process_experience("reason", "ok", True, {"workspace": name})
+
+        # 2. AZR analizza la risposta
+        analysis = self.azr.analyze(reason_resp.get("response", question))
+        self.autonomy.process_experience("azr", analysis, True, {"workspace": name})
+
+        # 3. Se AZR suggerisce problemi, genera patch con Codex
+        if analysis.startswith("❌"):
+            patch = self.codex.generate_project(prompt)
+            (ws["path"] / "patch.log").write_text(patch, encoding="utf-8")
+            self.autonomy.process_experience("codex_patch", patch, True, {"workspace": name})
+            result = self.executor.execute(patch)
+            (ws["path"] / "sandbox.log").write_text(str(result), encoding="utf-8")
+        self._log("cycle_completed", {"workspace": name})
+
+
+if __name__ == "__main__":
+    mc = MissionController()
+    ws = mc.create_workspace("demo", "Genera uno script di esempio")
+    mc.run_cycle("demo")


### PR DESCRIPTION
## Summary
- add `MissionController` to run a self-questioning loop across agents
- create Streamlit GUI to manage workspaces and trigger cycles
- document the new workflow in README

## Testing
- `pytest -q && echo OK`


------
https://chatgpt.com/codex/tasks/task_e_6841bcb8176083208fecfc6d4158569c