### PR TITLE
Add messaging layer and Josh bridge

### DIFF
--- a/integrations/bridge_josch.py
+++ b/integrations/bridge_josch.py
@@ -1,4 +1,14 @@
-# integrations/bridge_josch.py
+"""bridge_josch.py
+===================
+Interfaccia FastAPI per comunicare con il sistema "Josh" (alias JOSCH).
+
+Il modulo espone un piccolo server FastAPI che consente l'esecuzione remota
+di comandi su un sistema esterno e fornisce inoltre la funzione
+``send_command_to_pc`` da utilizzare all'interno di Mercurius∞ per inviare
+comandi al bridge.
+"""
+
+import requests
 
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
@@ -40,6 +50,21 @@ def run_command(req: CommandRequest):
 
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
+
+
+def send_command_to_pc(command: str, mode: str = "cmd", base_url: str = "http://localhost:3020") -> dict:
+    """Invia un comando al bridge JOSCH e restituisce la risposta JSON."""
+    try:
+        res = requests.post(
+            f"{base_url}/cmd",
+            json={"command": command, "mode": mode},
+            timeout=5,
+        )
+        if res.status_code == 200:
+            return res.json()
+        return {"error": res.text, "status": res.status_code}
+    except Exception as exc:
+        return {"error": str(exc)}
 
 
 def start_bridge(host="0.0.0.0", port=3020):

--- a/modules/messaging/__init__.py
+++ b/modules/messaging/__init__.py
@@ -1,0 +1,1 @@
+"""Utilities for internal messaging."""

--- a/modules/messaging/rabbitmq_messenger.py
+++ b/modules/messaging/rabbitmq_messenger.py
@@ -1,0 +1,59 @@
+"""rabbitmq_messenger.py
+=======================
+Modulo di messaggistica basato su RabbitMQ per Mercurius∞.
+
+Fornisce funzioni semplici per pubblicare e consumare messaggi utilizzando il
+protocollo AMQP tramite la libreria ``pika``. In assenza del server RabbitMQ le
+funzioni restituiscono errori gestiti senza sollevare eccezioni critiche.
+"""
+
+from typing import Callable, Optional
+
+import pika
+from utils.logger import setup_logger
+
+logger = setup_logger("RabbitMQMessenger")
+
+
+def publish_message(queue: str, message: str, url: str = "amqp://guest:guest@localhost:5672/") -> bool:
+    """Invia un messaggio alla coda specificata.
+
+    Ritorna ``True`` se l'operazione è andata a buon fine, altrimenti ``False``.
+    """
+    try:
+        params = pika.URLParameters(url)
+        connection = pika.BlockingConnection(params)
+        channel = connection.channel()
+        channel.queue_declare(queue=queue, durable=True)
+        channel.basic_publish(exchange="", routing_key=queue, body=message)
+        connection.close()
+        logger.info(f"[RabbitMQ] Sent to {queue}: {message}")
+        return True
+    except Exception as exc:
+        logger.error(f"[RabbitMQ] publish failed: {exc}")
+        return False
+
+
+def consume_messages(queue: str, handler: Callable[[str], None], url: str = "amqp://guest:guest@localhost:5672/", limit: Optional[int] = None) -> None:
+    """Consuma messaggi dalla coda chiamando ``handler`` per ogni messaggio.
+
+    ``limit`` permette di definire quante messaggi leggere prima di chiudere la
+    connessione (``None`` per ciclo infinito).
+    """
+    try:
+        params = pika.URLParameters(url)
+        connection = pika.BlockingConnection(params)
+        channel = connection.channel()
+        channel.queue_declare(queue=queue, durable=True)
+
+        count = 0
+        for method_frame, _properties, body in channel.consume(queue):
+            handler(body.decode())
+            channel.basic_ack(method_frame.delivery_tag)
+            count += 1
+            if limit and count >= limit:
+                break
+        channel.cancel()
+        connection.close()
+    except Exception as exc:
+        logger.error(f"[RabbitMQ] consume failed: {exc}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -214,3 +214,4 @@ zstandard==0.23.0
 scapy
 pybluez
 pywhatkit
+pika==1.3.2

--- a/tests/test_josch_bridge.py
+++ b/tests/test_josch_bridge.py
@@ -1,0 +1,5 @@
+from integrations.bridge_josch import send_command_to_pc
+
+def test_send_command_format():
+    resp = send_command_to_pc("echo test")
+    assert isinstance(resp, dict)

--- a/tests/test_messaging.py
+++ b/tests/test_messaging.py
@@ -1,0 +1,5 @@
+from modules.messaging.rabbitmq_messenger import publish_message
+
+def test_publish_message_no_server():
+    ok = publish_message('test_queue', 'hello')
+    assert ok in (True, False)


### PR DESCRIPTION
## Summary
- extend Josh bridge to allow command sending
- add RabbitMQ messenger utility
- include `pika` dependency
- test Josh connector and message layer

## Testing
- `pip install pika==1.3.2`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68432ff0b80c83208c68ece3a087629a