### PR TITLE
Ensure persistent boot and optional dependencies

### DIFF
--- a/scripts/aion_boot.py
+++ b/scripts/aion_boot.py
@@ -13,11 +13,13 @@ from utils.environment import Environment
 def main():
     print("🧬 Avvio AION – Modalità: dialogic-autonomous")
 
-    if sys.platform.startswith("win"):
+    os.environ.setdefault("PYTHONIOENCODING", "utf-8")
+    if hasattr(sys.stdout, "reconfigure"):
         try:
             sys.stdout.reconfigure(encoding="utf-8")
         except Exception:
             pass
+
 
     env = Environment()
     os.environ["RUN_MODE"] = "dialogic-autonomous"
@@ -46,9 +48,13 @@ def main():
         print(f"⚠️ Voice module non disponibile: {exc}")
 
     try:
-        from modules.dashboard import launch_dashboard
-        print("🖥️ Avvio dashboard...")
-        threading.Thread(target=launch_dashboard, daemon=True).start()
+        headless = env.get("HEADLESS", "0") == "1"
+        if not headless:
+            from modules.dashboard import launch_dashboard
+            print("🖥️ Avvio dashboard...")
+            threading.Thread(target=launch_dashboard, daemon=True).start()
+        else:
+            print("🖥️ Modalità headless attiva - dashboard disabilitata")
     except Exception as exc:
         print(f"⚠️ Dashboard non trovata: {exc}")
 

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -21,7 +21,7 @@ def setup_logger(name: str = "MercuriusLogger", logfile: str = "logs/execution.l
 
         if logfile:
             os.makedirs(os.path.dirname(logfile), exist_ok=True)
-            fh = logging.FileHandler(logfile)
+            fh = logging.FileHandler(logfile, encoding="utf-8")
             fh.setLevel(logging.DEBUG)
             fh.setFormatter(formatter)
             logger.addHandler(fh)
@@ -31,7 +31,7 @@ def get_file_logger(name="MercuriusFileLogger", filename="mercurius.log"):
     logger = logging.getLogger(name)
     if not logger.hasHandlers():
         logger.setLevel(logging.INFO)
-        fh = logging.FileHandler(filename)
+        fh = logging.FileHandler(filename, encoding="utf-8")
         formatter = logging.Formatter('[%(asctime)s] %(levelname)s - %(message)s')
         fh.setFormatter(formatter)
         logger.addHandler(fh)


### PR DESCRIPTION
## Summary
- keep `aion_boot` loop alive and allow headless mode
- handle missing `pika` in RabbitMQ messenger
- log files opened with UTF-8 encoding
- configure UTF-8 stdout by default

## Testing
- `pytest -q tests/test_agent_core.py::test_agent_boot`
- `pytest -q tests/test_audio_interface.py::test_audio_initialization tests/test_audio_interface.py::test_audio_listen_and_speak`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68468a7c6dbc83208e638809f96a3b19