### PR TITLE
Enable TradingView hook and auto service startup

### DIFF
--- a/ai_launcher.py
+++ b/ai_launcher.py
@@ -40,6 +40,12 @@ def ensure_ai_online():
     launch_service("AZR", "http://localhost:4010/introspect", ["python", "agents/azr_server.py"], delay=2)
     launch_service("JOSCH", "http://localhost:3020/ping", ["python", "integrations/bridge_josch.py"], delay=2)
     launch_service("n8n", "http://localhost:5678", ["n8n", "start"], delay=4)
+    try:
+        from trading.tv_watcher import start_watcher
+        start_watcher()
+        logger.info("tv_watcher avviato")
+    except Exception as exc:
+        logger.error(f"tv_watcher non avviato: {exc}")
 
 if __name__ == "__main__":
     ensure_ai_online()

--- a/integrations/bridge_josch.py
+++ b/integrations/bridge_josch.py
@@ -15,6 +15,8 @@ from pydantic import BaseModel
 import subprocess
 import uvicorn
 import time
+import json
+import os
 
 app = FastAPI(title="JOSCH Bridge")
 start_time = time.time()
@@ -50,6 +52,31 @@ def run_command(req: CommandRequest):
 
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
+
+
+@app.post("/tvhook")
+def tvhook(payload: dict):
+    """Riceve comandi da TradingView tramite n8n."""
+    file_path = os.path.join("logs", "tv_signal.json")
+    os.makedirs("logs", exist_ok=True)
+    try:
+        entries = []
+        if os.path.exists(file_path):
+            with open(file_path, "r", encoding="utf-8") as f:
+                entries = json.load(f)
+        if not isinstance(entries, list):
+            entries = []
+        entries.append({"timestamp": time.time(), "data": payload})
+        with open(file_path, "w", encoding="utf-8") as f:
+            json.dump(entries, f, ensure_ascii=False, indent=2)
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=f"Errore salvataggio segnale: {exc}")
+    try:
+        from trading.tv_watcher import handle_tv_signal
+        handle_tv_signal(payload)
+    except Exception:
+        pass
+    return {"status": "ok"}
 
 
 def send_command_to_pc(command: str, mode: str = "cmd", base_url: str = "http://localhost:3020") -> dict:

--- a/scripts/aion_boot.py
+++ b/scripts/aion_boot.py
@@ -8,6 +8,7 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 from core.orchestrator import Orchestrator
 from utils.environment import Environment
+from ai_launcher import ensure_ai_online
 
 
 def main():
@@ -24,6 +25,9 @@ def main():
     env = Environment()
     os.environ["RUN_MODE"] = "dialogic-autonomous"
     print(f"🌐 AION_RUN_MODE = {env.get('RUN_MODE')}")
+
+    print("🔧 Verifica servizi critici...")
+    ensure_ai_online()
 
     orchestrator = Orchestrator()
 

--- a/start_fullmode.py
+++ b/start_fullmode.py
@@ -1,6 +1,9 @@
 def main():
     print("🔁 Avvio completo Mercurius∞")
     print("🧠 Modalità Jarvis+ attiva: Visione, Voce, Dashboard, AI Cognitiva")
+    from ai_launcher import ensure_ai_online
+    ensure_ai_online()
+
     # Avviare sequenze di bootstrap dei moduli AI
     from modules.Neo.trainer_orchestrator import bootstrap_agents
     bootstrap_agents()

--- a/trading/tv_watcher.py
+++ b/trading/tv_watcher.py
@@ -1,0 +1,47 @@
+import json
+import os
+import time
+import threading
+
+from utils.logger import setup_logger
+
+TV_FILE = os.path.join("logs", "tv_signal.json")
+LOG_FILE = os.path.join("logs", "tv_watcher.log")
+
+logger = setup_logger("TVWatcher", LOG_FILE)
+
+
+def handle_tv_signal(data: dict) -> None:
+    """Gestisci un segnale TradingView appena ricevuto."""
+    logger.info(f"Nuovo segnale TV: {data}")
+
+
+def _read_signals():
+    if not os.path.exists(TV_FILE):
+        return []
+    try:
+        with open(TV_FILE, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except Exception as exc:
+        logger.error(f"Errore lettura {TV_FILE}: {exc}")
+        return []
+
+
+def watch_tv_signals(poll_interval: float = 5.0):
+    logger.info("TV watcher avviato")
+    last_len = 0
+    while True:
+        signals = _read_signals()
+        if len(signals) > last_len:
+            new = signals[last_len:]
+            last_len = len(signals)
+            for entry in new:
+                try:
+                    handle_tv_signal(entry.get("data", entry))
+                except Exception as exc:
+                    logger.error(f"Errore gestione segnale: {exc}")
+        time.sleep(poll_interval)
+
+
+def start_watcher():
+    threading.Thread(target=watch_tv_signals, daemon=True).start()


### PR DESCRIPTION
## Summary
- integrate new `/tvhook` endpoint in `bridge_josch` to log TradingView signals
- add `tv_watcher` module to monitor `logs/tv_signal.json`
- start `tv_watcher` via `ai_launcher.ensure_ai_online`
- call `ensure_ai_online` from `aion_boot.py` and `start_fullmode.py`

## Testing
- `pytest -k josch_bridge -q`

------
https://chatgpt.com/codex/tasks/task_e_684695aac86483208ed9d3f4785f19e3