### PR TITLE
Enable SELF_MISSION execution via Josch bridge

### DIFF
--- a/integrations/bridge_josch.py
+++ b/integrations/bridge_josch.py
@@ -17,6 +17,7 @@ import uvicorn
 import time
 import json
 import os
+from scripts.run_selfmission import run_codex_from_md
 
 app = FastAPI(title="JOSCH Bridge")
 start_time = time.time()
@@ -35,6 +36,11 @@ def ping():
 @app.post("/cmd")
 def run_command(req: CommandRequest):
     try:
+        if req.command.strip().startswith("#SELF_MISSION:"):
+            path = req.command.split(":", 1)[1].strip()
+            output = run_codex_from_md(path)
+            return {"returncode": 0, "stdout": output, "stderr": ""}
+
         if req.mode == "cmd":
             result = subprocess.run(req.command, shell=True, capture_output=True, text=True)
         elif req.mode == "powershell":

--- a/scripts/run_selfmission.py
+++ b/scripts/run_selfmission.py
@@ -1,0 +1,19 @@
+def run_codex_from_md(path: str) -> str:
+    import os
+    import markdown
+    import re
+
+    if not os.path.exists(path):
+        return f"File non trovato: {path}"
+
+    with open(path, "r", encoding="utf-8") as f:
+        content = f.read()
+
+    blocks = re.findall(r"```python(.*?)```", content, re.DOTALL)
+    if not blocks:
+        return "Nessun blocco Python trovato"
+
+    for block in blocks:
+        exec(block.strip(), globals())
+
+    return f"SELF_MISSION eseguita da {path}"


### PR DESCRIPTION
## Summary
- allow executing SELF_MISSION markdown through the JOSCH `/cmd` API
- add `run_codex_from_md` helper script for parsing python blocks

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846c6ab3c2c83209c82abf851f9e878