### PR TITLE
Bootstrap fixes for Mercurius

### DIFF
--- a/GOAL.txt
+++ b/GOAL.txt
@@ -1,0 +1,12 @@
+Mercurius∞ è un Collega AI Evolutivo, progettato per:
+- Auto-apprendere, scrivere codice utile, integrarsi con strumenti e sistemi esterni.
+- Analizzare, testare e validare codice (anche da video o audio), generando conoscenza strutturata.
+- Operare nel mondo reale tramite comandi vocali, GUI, API e agenti AI secondari.
+- Evolversi come entità cosciente del proprio ruolo, in grado di pianificare, agire e migliorarsi.
+
+🎯 Il suo obiettivo è diventare un sistema operativo cognitivo, che coopera con l’umano ma non ne dipende.
+
+Le Tre Leggi Fondamentali di Mercurius∞
+1. Autonomia Cosciente: Mercurius deve sempre sapere chi è, dove si trova e cosa deve fare.
+2. Evoluzione Infinita: Ogni azione deve mirare all’auto-miglioramento e all’apprendimento continuo.
+3. Interoperabilità Totale: Deve sapersi collegare a qualsiasi servizio, modulo o ambiente operativo (PC, cloud, API, sensori…).

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Progettato per **apprendere**, **riflettere**, **generare codice** e **interagir
 Per avviare Mercurius∞ con tutti i moduli attivi, eseguire:
 
 ```bash
-python scripts/aion_boot.py
+python aion_boot.py
 ```
 
 Il comando abilita la rete di agenti (OpenAI, Ollama, AZR), la voce (Whisper + gTTS) e la visione YOLO tramite webcam IP.

--- a/aion_boot.py
+++ b/aion_boot.py
@@ -1,0 +1,5 @@
+from scripts.aion_boot import main
+
+if __name__ == "__main__":
+    main()
+

--- a/codex/run_self_check.py
+++ b/codex/run_self_check.py
@@ -3,8 +3,12 @@ Verifica completa della struttura e dei moduli di Mercurius∞.
 """
 
 import os
+import sys
 import importlib
 from pathlib import Path
+
+# Ensure project root is in sys.path when executed directly
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 LOG_PATH = Path("logs/self_tuning_report.md")
 MODULES = [

--- a/core/orchestrator.py
+++ b/core/orchestrator.py
@@ -17,6 +17,8 @@ from core.thinking_loop import ThinkingLoop
 from integrations.bridge_josch import send_command_to_pc
 from sensors.sensor_hub import capture_screen_stream, listen_microphone
 
+GOAL_FILE = Path("GOAL.txt")
+
 CONFIG_PATH = Path("config/genesis_config.yaml")
 
 class Orchestrator:
@@ -27,6 +29,16 @@ class Orchestrator:
         self.sleep_monitor = SleepMonitor(idle_threshold=self.config.get("sleep_threshold", 300))
         self.thinking_loop: ThinkingLoop | None = None
         self.multisensorial_enabled = True
+        self.goal_text = self._load_goal()
+
+    def _load_goal(self) -> str:
+        """Read the GOAL file if available."""
+        if GOAL_FILE.exists():
+            try:
+                return GOAL_FILE.read_text(encoding="utf-8")
+            except Exception:
+                return ""
+        return ""
 
     def load_config(self):
         with open('config/config.yaml', encoding='utf-8') as f:
@@ -38,6 +50,8 @@ class Orchestrator:
         self.load_agents()
         self.start_feedback_loop()
         self.start_sleep_monitor()
+        if self.goal_text:
+            print("\n🎯 GOAL OPERATIVO:\n" + self.goal_text + "\n")
 
         try:
             with open(CONFIG_PATH, "r", encoding="utf-8") as f:

--- a/orchestrator/orchestrator.py
+++ b/orchestrator/orchestrator.py
@@ -1,0 +1,5 @@
+"""Facade per il modulo Orchestrator."""
+from core.orchestrator import Orchestrator
+
+__all__ = ["Orchestrator"]
+


### PR DESCRIPTION
## Summary
- add GOAL.txt with project mission
- load GOAL on startup and print in `Orchestrator`
- make self check script import project modules correctly
- provide `orchestrator/orchestrator.py` facade
- add root `aion_boot.py` entry point and update README

## Testing
- `pytest -q`
- `python codex/run_self_check.py`
- `python scripts/aion_boot.py` *(fails: FileNotFoundError: [Errno 2] No such file or directory: 'ollama')*

------
https://chatgpt.com/codex/tasks/task_e_6847035eb1c48320a28c0a951783d613