### PR TITLE
Fix genesis startup scripts and teacher mode

### DIFF
--- a/azr.bat
+++ b/azr.bat
@@ -1,0 +1,4 @@
+@echo off
+rem Avvia il reasoner AZR
+python modules\llm\azr_reasoner.py %*
+

--- a/bridge_josch.bat
+++ b/bridge_josch.bat
@@ -1,0 +1,4 @@
+@echo off
+rem Avvia il bridge JOSCH su porta 3020
+python integrations\bridge_josch.py %*
+

--- a/modules/teacher_mode.py
+++ b/modules/teacher_mode.py
@@ -41,3 +41,16 @@ class TeacherMode:
                 if feedback:
                     speak_feedback(feedback)
             time.sleep(5)
+
+    def start(self) -> None:
+        """Avvia la modalità tutor in un loop continuo (placeholder)."""
+        self.toggle(True)
+        logger.info("👨‍🏫 TeacherMode start() avviato")
+        try:
+            while self.active:
+                logger.debug("TeacherMode heartbeat")
+                time.sleep(10)
+        except Exception as exc:  # pragma: no cover - runtime safeguard
+            logger.error("TeacherMode error: %s", exc)
+        finally:
+            self.active = False

--- a/n8n.bat
+++ b/n8n.bat
@@ -1,0 +1,8 @@
+@echo off
+rem Avvia n8n. Configurare il percorso se non presente nel PATH.
+rem Esempio: set N8N_HOME=C:\path\to\n8n
+rem call "%N8N_HOME%\node_modules\.bin\n8n" start
+
+rem Se n8n e' nel PATH, il comando seguente e' sufficiente
+n8n start
+


### PR DESCRIPTION
## Summary
- add a placeholder `start()` method in `teacher_mode` to allow thread startup
- provide Windows batch launchers for AZR, n8n and bridge_josch services

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684822ba11708320913012c67898bca4