### PR TITLE
Add trading knowledge base and basic auto trader

### DIFF
--- a/datasets/trading.jsonl
+++ b/datasets/trading.jsonl
@@ -1,0 +1,36 @@
+{"prompt": "# Analisi Tecnica TOT", "completion": ""}
+{"prompt": "Sintesi delle tecniche di analisi tecnica moderne basate sui testi di John J. Murphy e Steve Nison. L'obiettivo è riconoscere pattern grafici, trend e segnali di inversione con indicatori standard come RSI e medie mobili.", "completion": ""}
+{"prompt": "# Backtesting", "completion": ""}
+{"prompt": "Metodologia di verifica storica delle strategie tramite piattaforme come TradingView e Backtrader. Importanza di metriche quali Sharpe e drawdown.", "completion": ""}
+{"prompt": "# Crypto", "completion": ""}
+{"prompt": "Analisi dei mercati digitali con particolare focus su Bitcoin ed Ethereum. Strategie di sicurezza per la custodia e gestione delle chiavi.", "completion": ""}
+{"prompt": "# Investimenti", "completion": ""}
+{"prompt": "Principi base di asset allocation ed ETF secondo la metodologia di Meb Faber. Diversificazione globale e ribilanciamento periodico.", "completion": ""}
+{"prompt": "# Liquidità", "completion": ""}
+{"prompt": "Comprendere i concetti di liquidità di mercato e slippage seguendo gli studi di Michael Halls-Moore. Gestione di ordini in mercati poco liquidi.", "completion": ""}
+{"prompt": "# Mindset", "completion": ""}
+{"prompt": "Lezioni sul controllo emotivo e disciplina ispirate a Mark Douglas. Comprendere i bias psicologici e adottare un approccio sistematico agli errori.", "completion": ""}
+{"prompt": "# Money Management", "completion": ""}
+{"prompt": "Gestione del rischio secondo il modello di position sizing di Van Tharp. Include calcolo di rischio percentuale per trade e uso del trailing stop per proteggere i profitti.", "completion": ""}
+{"prompt": "# Opzioni TOT", "completion": ""}
+{"prompt": "Elementi fondamentali sulle opzioni finanziarie secondo il manuale di Sheldon Natenberg. Spiegazione di Delta, Gamma e strategie di spread.", "completion": ""}
+{"prompt": "# Piano d'Azione", "completion": ""}
+{"prompt": "Guida per definire obiettivi, tempi e metodi di valutazione delle performance. Riferimenti al \"One Good Trade\" di Mike Bellafiore.", "completion": ""}
+{"prompt": "# Preparazione", "completion": ""}
+{"prompt": "Checklist giornaliera prima dell'apertura dei mercati: controllo calendario economico, verifica delle posizioni e impostazione livelli chiave. Ispirato a Lance Beggs.", "completion": ""}
+{"prompt": "# Price Action", "completion": ""}
+{"prompt": "Studio delle dinamiche di prezzo puro ispirato alle lezioni di Al Brooks. Identificazione di breakout, pullback e zone di compressione senza uso di indicatori.", "completion": ""}
+{"prompt": "# Quant Analysis", "completion": ""}
+{"prompt": "Introduzione alla statistica applicata al trading seguendo i lavori di Ernest Chan. Utilizzo di Python e librerie come pandas per costruire strategie quantitative.", "completion": ""}
+{"prompt": "# Recessione", "completion": ""}
+{"prompt": "Aspetti economici e indicatori per valutare fasi di recessione basati su ricerche di Ray Dalio. Comprendere come proteggere il capitale in cicli economici negativi.", "completion": ""}
+{"prompt": "# Smart Money Trading", "completion": ""}
+{"prompt": "Approccio basato sui concetti di ICT e SMC. Si analizzano i livelli istituzionali, gli order block e le liquidity grab per entrare con precisione sul mercato.", "completion": ""}
+{"prompt": "# Strategie", "completion": ""}
+{"prompt": "Raccolta delle migliori strategie studiate da trader come Rayner Teo e Adam Grimes. Si analizzano i setup trend following, breakout e mean reversion con esempi pratici.", "completion": ""}
+{"prompt": "# Trading/Investing Plan", "completion": ""}
+{"prompt": "Come strutturare un piano operativo completo dal time frame di analisi alle regole di gestione e revisione periodica. Riferimento al metodo di Brian Shannon.", "completion": ""}
+{"prompt": "# Volume Profile TOT", "completion": ""}
+{"prompt": "Studio del Volume Profile secondo i webinar di Trader Dale e i manuali di futures. Analisi delle zone di alto volume per identificare supporti e resistenze significative.", "completion": ""}
+{"prompt": "# Wyckoff", "completion": ""}
+{"prompt": "Strategia basata sul ciclo di accumulazione e distribuzione di Richard D. Wyckoff. Include esempi di Spring, Upthrust e test di supporto.", "completion": ""}

--- a/learn/trading/analisi_tecnica_tot.md
+++ b/learn/trading/analisi_tecnica_tot.md
@@ -1,0 +1,3 @@
+# Analisi Tecnica TOT
+
+Sintesi delle tecniche di analisi tecnica moderne basate sui testi di John J. Murphy e Steve Nison. L'obiettivo è riconoscere pattern grafici, trend e segnali di inversione con indicatori standard come RSI e medie mobili.

--- a/learn/trading/backtesting.md
+++ b/learn/trading/backtesting.md
@@ -1,0 +1,3 @@
+# Backtesting
+
+Metodologia di verifica storica delle strategie tramite piattaforme come TradingView e Backtrader. Importanza di metriche quali Sharpe e drawdown.

--- a/learn/trading/crypto.md
+++ b/learn/trading/crypto.md
@@ -1,0 +1,3 @@
+# Crypto
+
+Analisi dei mercati digitali con particolare focus su Bitcoin ed Ethereum. Strategie di sicurezza per la custodia e gestione delle chiavi.

--- a/learn/trading/investimenti.md
+++ b/learn/trading/investimenti.md
@@ -1,0 +1,3 @@
+# Investimenti
+
+Principi base di asset allocation ed ETF secondo la metodologia di Meb Faber. Diversificazione globale e ribilanciamento periodico.

--- a/learn/trading/liquidita.md
+++ b/learn/trading/liquidita.md
@@ -1,0 +1,3 @@
+# Liquidità
+
+Comprendere i concetti di liquidità di mercato e slippage seguendo gli studi di Michael Halls-Moore. Gestione di ordini in mercati poco liquidi.

--- a/learn/trading/mindset.md
+++ b/learn/trading/mindset.md
@@ -1,0 +1,3 @@
+# Mindset
+
+Lezioni sul controllo emotivo e disciplina ispirate a Mark Douglas. Comprendere i bias psicologici e adottare un approccio sistematico agli errori.

--- a/learn/trading/money_management.md
+++ b/learn/trading/money_management.md
@@ -1,0 +1,3 @@
+# Money Management
+
+Gestione del rischio secondo il modello di position sizing di Van Tharp. Include calcolo di rischio percentuale per trade e uso del trailing stop per proteggere i profitti.

--- a/learn/trading/opzioni_tot.md
+++ b/learn/trading/opzioni_tot.md
@@ -1,0 +1,3 @@
+# Opzioni TOT
+
+Elementi fondamentali sulle opzioni finanziarie secondo il manuale di Sheldon Natenberg. Spiegazione di Delta, Gamma e strategie di spread.

--- a/learn/trading/piano_dazione.md
+++ b/learn/trading/piano_dazione.md
@@ -1,0 +1,3 @@
+# Piano d'Azione
+
+Guida per definire obiettivi, tempi e metodi di valutazione delle performance. Riferimenti al "One Good Trade" di Mike Bellafiore.

--- a/learn/trading/preparazione.md
+++ b/learn/trading/preparazione.md
@@ -1,0 +1,3 @@
+# Preparazione
+
+Checklist giornaliera prima dell'apertura dei mercati: controllo calendario economico, verifica delle posizioni e impostazione livelli chiave. Ispirato a Lance Beggs.

--- a/learn/trading/price_action.md
+++ b/learn/trading/price_action.md
@@ -1,0 +1,3 @@
+# Price Action
+
+Studio delle dinamiche di prezzo puro ispirato alle lezioni di Al Brooks. Identificazione di breakout, pullback e zone di compressione senza uso di indicatori.

--- a/learn/trading/quant_analysis.md
+++ b/learn/trading/quant_analysis.md
@@ -1,0 +1,3 @@
+# Quant Analysis
+
+Introduzione alla statistica applicata al trading seguendo i lavori di Ernest Chan. Utilizzo di Python e librerie come pandas per costruire strategie quantitative.

--- a/learn/trading/recessione.md
+++ b/learn/trading/recessione.md
@@ -1,0 +1,3 @@
+# Recessione
+
+Aspetti economici e indicatori per valutare fasi di recessione basati su ricerche di Ray Dalio. Comprendere come proteggere il capitale in cicli economici negativi.

--- a/learn/trading/smart_money_trading.md
+++ b/learn/trading/smart_money_trading.md
@@ -1,0 +1,3 @@
+# Smart Money Trading
+
+Approccio basato sui concetti di ICT e SMC. Si analizzano i livelli istituzionali, gli order block e le liquidity grab per entrare con precisione sul mercato.

--- a/learn/trading/strategie.md
+++ b/learn/trading/strategie.md
@@ -1,0 +1,3 @@
+# Strategie
+
+Raccolta delle migliori strategie studiate da trader come Rayner Teo e Adam Grimes. Si analizzano i setup trend following, breakout e mean reversion con esempi pratici.

--- a/learn/trading/trading_investing_plan.md
+++ b/learn/trading/trading_investing_plan.md
@@ -1,0 +1,3 @@
+# Trading/Investing Plan
+
+Come strutturare un piano operativo completo dal time frame di analisi alle regole di gestione e revisione periodica. Riferimento al metodo di Brian Shannon.

--- a/learn/trading/volume_profile_tot.md
+++ b/learn/trading/volume_profile_tot.md
@@ -1,0 +1,3 @@
+# Volume Profile TOT
+
+Studio del Volume Profile secondo i webinar di Trader Dale e i manuali di futures. Analisi delle zone di alto volume per identificare supporti e resistenze significative.

--- a/learn/trading/wyckoff.md
+++ b/learn/trading/wyckoff.md
@@ -1,0 +1,3 @@
+# Wyckoff
+
+Strategia basata sul ciclo di accumulazione e distribuzione di Richard D. Wyckoff. Include esempi di Spring, Upthrust e test di supporto.

--- a/modules/auto_trader_ai.py
+++ b/modules/auto_trader_ai.py
@@ -1,0 +1,25 @@
+"""Modulo per l'esecuzione di trading semi-automatico."""
+
+from modules.FinRLAgent import FinRLAgent
+from trading.trading_core import TradingViewInterface
+
+
+n_default_qty = 1.0
+
+
+class AutoTraderAI:
+    """Implementazione semplice di un trader automatico."""
+
+    def __init__(self, quantity: float = n_default_qty):
+        self.finrl = FinRLAgent()
+        self.tv = TradingViewInterface()
+        self.quantity = quantity
+        self.tv.connect()
+
+    def run(self, market_data: list[dict]) -> list[dict]:
+        """Analizza dati e invia ordini simulati."""
+        analyses = self.finrl.analyze_market(market_data)
+        signals = self.finrl.generate_trade_signals(analyses)
+        for s in signals:
+            self.tv.execute_order(s["symbol"], s["action"], self.quantity)
+        return signals

--- a/scripts/tradingview_test.py
+++ b/scripts/tradingview_test.py
@@ -1,0 +1,14 @@
+"""Esegue una prova rapida del modulo TradingView."""
+
+from trading.trading_core import TradingViewInterface
+
+
+def main() -> None:
+    tv = TradingViewInterface()
+    tv.connect()
+    tv.execute_order("BTCUSD", "buy", 1)
+    print(tv.get_status())
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/trading/test_auto_trader_ai.py
+++ b/tests/trading/test_auto_trader_ai.py
@@ -1,0 +1,9 @@
+from modules.auto_trader_ai import AutoTraderAI
+
+
+def test_run_returns_signals():
+    ai = AutoTraderAI()
+    market_data = [{'symbol': 'XYZ', 'volatility': 1.2}]
+    signals = ai.run(market_data)
+    assert isinstance(signals, list)
+    assert signals

--- a/tests/trading/test_lessons.py
+++ b/tests/trading/test_lessons.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+
+TOPICS = [
+    'analisi_tecnica_tot',
+    'strategie',
+    'money_management',
+    'mindset',
+    'volume_profile_tot',
+    'smart_money_trading',
+    'wyckoff',
+    'trading_investing_plan',
+    'recessione',
+    'investimenti',
+    'crypto',
+    'price_action',
+    'liquidita',
+    'backtesting',
+    'preparazione',
+    'piano_dazione',
+    'quant_analysis',
+    'opzioni_tot',
+]
+
+
+def test_lesson_files_exist():
+    base = Path('learn/trading')
+    for t in TOPICS:
+        assert (base / f"{t}.md").exists()


### PR DESCRIPTION
## Summary
- create `learn/trading` lessons covering various trading topics
- generate dataset `datasets/trading.jsonl`
- add `AutoTraderAI` module and TradingView test script
- include simple tests for new lessons and module

## Testing
- `pip install cerberus mss`
- `pip install pillow`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ad8115d8c8320b26f727c3ad19d0e